### PR TITLE
Fix CI (remove EOL Python, tests on PR against master, pytest-pydocstyle version Sphinx version, fix tests due to Babel thin space)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: main
+    branches: master
   pull_request:
-    branches: main
+    branches: master
   schedule:
     # * is a special character in YAML so you have to quote this string
     - cron:  '0 3 * * 6'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-          python-version: [3.6, 3.7, 3.8]
+          python-version: [3.8, 3.9]
           services: [release, lowest]
           include:
           - services: release

--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ Let's format some EDTF strings:
 'jan.–sep. 2020'
 
 >>> format_edtf('2020-01/2020-09', format='long', locale='en')
-'January – September 2020'
+'January\u2009–\u2009September 2020'
 
 The following formats are supported:
 

--- a/babel_edtf/__init__.py
+++ b/babel_edtf/__init__.py
@@ -13,7 +13,9 @@ from babel import Locale
 from babel.dates import LC_TIME, format_date, format_interval, format_skeleton
 from dateutil.parser import isoparse
 from edtf import PRECISION_DAY, PRECISION_MONTH, PRECISION_YEAR, Date, \
-    EDTFObject, Interval, struct_time_to_datetime, parse_edtf as edtf_parse_edtf
+    EDTFObject, Interval
+from edtf import parse_edtf as edtf_parse_edtf
+from edtf import struct_time_to_datetime
 from edtf.parser.grammar import ParseException
 
 from .version import __version__
@@ -171,6 +173,7 @@ def _format_edtf0_interval_naive(edtf_interval, format, locale):
     return format_interval(
         dt_start, dt_end, skeleton, fuzzy=True, locale=locale)
 
+
 def parse_edtf(date):
     """parse_edtf after trying isoparse for simple date formats.
 
@@ -181,7 +184,11 @@ def parse_edtf(date):
     if len(date) == 10:
         try:
             isodate = isoparse(date)
-            return Date(str(isodate.year), str(isodate.month).zfill(2), str(isodate.day).zfill(2))
+            return Date(
+                str(isodate.year),
+                str(isodate.month).zfill(2),
+                str(isodate.day).zfill(2),
+            )
         except Exception:
             pass
     return edtf_parse_edtf(date)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -71,7 +71,7 @@ release = version
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:

--- a/setup.py
+++ b/setup.py
@@ -36,11 +36,11 @@ for reqs in extras_require.values():
     extras_require['all'].extend(reqs)
 
 setup_requires = [
-    'Babel>=2.8',
+    'Babel>=2.12',
 ]
 
 install_requires = [
-    'Babel>=2.8',
+    'Babel>=2.12',
     'edtf>=4.0.1',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ tests_require = [
 
 extras_require = {
     'docs': [
-        'Sphinx>=3,<4',
+        'Sphinx>=5,<6',
     ],
     'tests': tests_require,
 }

--- a/setup.py
+++ b/setup.py
@@ -20,8 +20,8 @@ tests_require = [
     'pytest-cov>=2.10.1',
     'pytest-isort>=1.2.0',
     'pytest-pycodestyle>=2.2.0',
-    'pytest-pydocstyle>=2.2.0',
-    'pytest>=6,<7',
+    'pytest-pydocstyle>=2.3.2',
+    'pytest>=7,<8',
 ]
 
 extras_require = {

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -13,6 +13,8 @@ import pytest
 
 from babel_edtf import edtf_to_datetime, format_edtf, parse_edtf_level0
 
+separator = '\u2009–\u2009'
+
 
 @pytest.mark.parametrize('edtfstr,locale,format,expected', [
     # ## Dates
@@ -48,38 +50,53 @@ from babel_edtf import edtf_to_datetime, format_edtf, parse_edtf_level0
     ('2020-09-30', 'da', 'full', 'onsdag den 30. september 2020'),
     # ### Intervals (same precision)
     # Year (en)
-    ('2020/2021', 'en', 'short', '2020 – 2021'),
-    ('2020/2021', 'en', 'medium', '2020 – 2021'),
-    ('2020/2021', 'en', 'long', '2020 – 2021'),
-    ('2020/2021', 'en', 'full', '2020 – 2021'),
+    ('2020/2021', 'en', 'short', f'2020{separator}2021'),
+    ('2020/2021', 'en', 'medium', f'2020{separator}2021'),
+    ('2020/2021', 'en', 'long', f'2020{separator}2021'),
+    ('2020/2021', 'en', 'full', f'2020{separator}2021'),
     # Year (da)
     ('2020/2021', 'da', 'short', '2020–2021'),
     ('2020/2021', 'da', 'medium', '2020–2021'),
     ('2020/2021', 'da', 'long', '2020–2021'),
     ('2020/2021', 'da', 'full', '2020–2021'),
     # Year-Month (constant year) (en)
-    ('2020-09/2020-11', 'en', 'short', '9/2020 – 11/2020'),
-    ('2020-09/2020-11', 'en', 'medium', 'Sep – Nov 2020'),
-    ('2020-09/2020-11', 'en', 'long', 'September – November 2020'),
-    ('2020-09/2020-11', 'en', 'full', 'September – November 2020'),
+    ('2020-09/2020-11', 'en', 'short', f'9/2020{separator}11/2020'),
+    ('2020-09/2020-11', 'en', 'medium', f'Sep{separator}Nov 2020'),
+    ('2020-09/2020-11', 'en', 'long', f'September{separator}November 2020'),
+    ('2020-09/2020-11', 'en', 'full', f'September{separator}November 2020'),
     # Year-Month (different year) (en)
-    ('2020-09/2021-11', 'en', 'short', '9/2020 – 11/2021'),
-    ('2020-09/2021-11', 'en', 'medium', 'Sep 2020 – Nov 2021'),
-    ('2020-09/2021-11', 'en', 'long', 'September 2020 – November 2021'),
-    ('2020-09/2021-11', 'en', 'full', 'September 2020 – November 2021'),
+    ('2020-09/2021-11', 'en', 'short', f'9/2020{separator}11/2021'),
+    ('2020-09/2021-11', 'en', 'medium', f'Sep 2020{separator}Nov 2021'),
+    (
+        '2020-09/2021-11',
+        'en',
+        'long',
+        f'September 2020{separator}November 2021'
+    ),
+    (
+        '2020-09/2021-11',
+        'en',
+        'full',
+        f'September 2020{separator}November 2021'
+    ),
     # Year-Month (reverse chronological order) (da)
     ('2021-11/2020-09', 'da', 'full', 'november 2021–september 2020'),
     # Year-Month-Day (en)
-    ('2020-09-01/2020-11-15', 'en', 'short', '9/1/2020 – 11/15/2020'),
-    ('2020-09-01/2020-11-15', 'en', 'medium', 'Sep 1 – Nov 15, 2020'),
+    ('2020-09-01/2020-11-15', 'en', 'short', f'9/1/2020{separator}11/15/2020'),
+    ('2020-09-01/2020-11-15', 'en', 'medium', f'Sep 1{separator}Nov 15, 2020'),
     # Note the next two lines. For date intervals we are forced to use
     # format_skeleton, and thus these lines differ in format from other
     # long/full formats.
-    ('2020-09-01/2020-11-15', 'en', 'long', 'Sep 1 – Nov 15, 2020'),
-    ('2020-09-01/2020-11-15', 'en', 'full', 'Tue, Sep 1 – Sun, Nov 15, 2020'),
+    ('2020-09-01/2020-11-15', 'en', 'long', f'Sep 1{separator}Nov 15, 2020'),
+    (
+        '2020-09-01/2020-11-15',
+        'en',
+        'full',
+        f'Tue, Sep 1{separator}Sun, Nov 15, 2020'
+    ),
     # ### Intervals (different precision)
-    ('2020-09-02/2020-11', 'en', 'long', 'Sep 2 – Nov 30, 2020'),
-    ('2020-09/2020-11-15', 'en', 'long', 'Sep 1 – Nov 15, 2020'),
+    ('2020-09-02/2020-11', 'en', 'long', f'Sep 2{separator}Nov 30, 2020'),
+    ('2020-09/2020-11-15', 'en', 'long', f'Sep 1{separator}Nov 15, 2020'),
 ])
 def test_format_edtf(edtfstr, locale, format, expected):
     assert format_edtf(edtfstr, format=format, locale=locale) == expected
@@ -120,4 +137,4 @@ def test_format_edtf_format():
     """Test overriding the format."""
     assert format_edtf('2020-11', format='yMd', locale='en') == '11/1/2020'
     assert format_edtf('2020/2021', format='yM', locale='en') == \
-        '1/2020 – 12/2021'
+        f'1/2020{separator}12/2021'


### PR DESCRIPTION
This pull request;s goal is to fix the CI which has been broken for some time.

All the of following changes are required in order to get back to green:

* installation: fix sphinx dependency
* ci: fix master branch name
* tests: fix ValueError introduced by pytest-pydocstyle
* formatting: fix isort and pycodestyle errors
* tests: interval separator with thin spaces introduced in babel 2.12
* ci: remove python 3.6 and 3.7 which are end-of-life