### PR TITLE
fix: fail parsing 29th of February on non-leap years & release: v1.1.4

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,10 @@
 Changes
 =======
 
+Version 1.1.4 (released 2024-03-05)
+
+- fix: fail parsing 29th of February on leap years
+
 Version 1.1.3 (released 2023-11-01)
 
 - global: use custom parse_edtf in parse_edtf_level0

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,22 @@
 Changes
 =======
 
+Version 1.1.3 (released 2023-11-01)
+
+- global: use custom parse_edtf in parse_edtf_level0
+
+Version 1.1.2 (released 2023-10-19)
+
+- add leading zeros for precise month and day
+
+Version 1.1.1 (released 2023-10-19)
+
+- convert isoparse values to string
+
+Version 1.1.0 (released 2023-10-19)
+
+- Add parse_edtf isoparse backed method
+
 Version 1.0.0 (released 2020-11-06)
 
 - Initial public release.

--- a/babel_edtf/version.py
+++ b/babel_edtf/version.py
@@ -11,4 +11,4 @@ This file is imported by ``babel_edtf.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = '1.1.3'
+__version__ = '1.1.4'


### PR DESCRIPTION
Closes https://github.com/zenodo/ops/issues/379

:heart: Thank you for your contribution!

### Description

python-edtf's `edtf_parse_edtf` uses [a grammar that allows days up to 29 for the month of February](https://github.com/ixc/python-edtf/blob/master/edtf/parser/grammar.py#L35) regardless of whether the year is a leap year or not.

This pull request proposes to fail in case we hit this corner case.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/) (for relevant code).
- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines (for relevant code).
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines (for relevant code).
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines (for relevant code).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).

**Third-party code**

If you've added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
