### PR TITLE
setup: upgrade edtf to 5.0.0 and fix bug with dates and times with hour 23 & release: v1.2.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,7 +56,7 @@ jobs:
           pip install -e .[all]
           pip freeze
           docker --version
-          docker-compose --version
+          docker compose --version
 
       - name: Run tests
         run: |

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,11 +1,15 @@
 ..
-    Copyright (C) 2020 CERN.
+    Copyright (C) 2020-2024 CERN.
 
     Babel-EDTF is free software; you can redistribute it and/or modify it
     under the terms of the MIT License; see LICENSE file for more details.
 
 Changes
 =======
+
+Version 1.2.0 (released 2024-10-28)
+
+- setup: upgrade edtf to 5.0.0 and fix bug with dates and times with hour 23
 
 Version 1.1.4 (released 2024-03-05)
 

--- a/babel_edtf/__init__.py
+++ b/babel_edtf/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2020 CERN.
+# Copyright (C) 2020-2024 CERN.
 #
 # Babel-EDTF is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
@@ -13,11 +13,12 @@ from datetime import date as date_
 from babel import Locale
 from babel.dates import LC_TIME, format_date, format_interval, format_skeleton
 from dateutil.parser import isoparse
-from edtf import PRECISION_DAY, PRECISION_MONTH, PRECISION_YEAR, Date, \
-    EDTFObject, Interval
+from edtf import Date, EDTFObject, Interval
 from edtf import parse_edtf as edtf_parse_edtf
 from edtf import struct_time_to_datetime
 from edtf.parser.grammar import EDTFParseException, ParseException
+from edtf.parser.parser_classes import PRECISION_DAY, PRECISION_MONTH, \
+    PRECISION_YEAR
 
 from .version import __version__
 

--- a/babel_edtf/version.py
+++ b/babel_edtf/version.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2020 CERN.
+# Copyright (C) 2020-2024 CERN.
 #
 # Babel-EDTF is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
@@ -11,4 +11,4 @@ This file is imported by ``babel_edtf.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = '1.1.4'
+__version__ = '1.2.0'

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2020 CERN.
+# Copyright (C) 2020-2024 CERN.
 #
 # Babel-EDTF is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
@@ -41,7 +41,7 @@ setup_requires = [
 
 install_requires = [
     'Babel>=2.12',
-    'edtf>=4.0.1',
+    'edtf>=5.0.0,<6.0.0',
 ]
 
 packages = find_packages()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2020 CERN.
+# Copyright (C) 2020-2024 CERN.
 #
 # Babel-EDTF is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
@@ -165,7 +165,7 @@ def test_format_edtf_format():
 ])
 def test_parse_edtf(edtfstr, expected):
     """Test valid values to parse_edtf."""
-    parse_edtf(edtfstr) == expected
+    assert parse_edtf(edtfstr) == expected
 
 
 @pytest.mark.parametrize('edtfstr', [

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -108,7 +108,13 @@ def test_format_edtf(edtfstr, locale, format, expected):
 def test_format_edtf_invalid():
     """Test invalid values to format_edtf."""
     pytest.raises(ValueError, format_edtf, 'invalid')
-    pytest.raises(ValueError, format_edtf, '2021/')
+
+    # With version 5.0.0, this is parsed as an interval,
+    # but `interval.lower` is of type `UncertainOrApproximate`,
+    # so the precision cannot be determined for formatting,
+    # hence the `AttributeError`.
+    pytest.raises(AttributeError, format_edtf, '2021/')
+
     pytest.raises(ValueError, format_edtf, '2020?')
     pytest.raises(TypeError, format_edtf, 2020)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -10,7 +10,7 @@
 from datetime import datetime
 
 import pytest
-from edtf import Date, Interval
+from edtf import Date, DateAndTime, Interval
 from edtf.parser.edtf_exceptions import EDTFParseException
 
 from babel_edtf import edtf_to_datetime, format_edtf, parse_edtf, \
@@ -144,6 +144,7 @@ def test_format_edtf_format():
 
 
 @pytest.mark.parametrize('edtfstr,expected', [
+    # ## Dates
     # Year in range
     ('2020', Date('2020')),
     ('2020/2021', Interval(Date('2020'), Date('2021'))),
@@ -161,6 +162,27 @@ def test_format_edtf_format():
     (
         '2020-02-29/2020-12-31',
         Interval(Date('2020', '02', '29'), Date('2020', '12', '31'))
+    ),
+    # ## Dates and times
+    # Complete representations for calendar date and (local) time of day
+    (
+        '1985-04-12T23:20:30',
+        DateAndTime(Date('1985', '04', '12'), '23:20:30')
+    ),
+    # Complete representations for calendar date and UTC time of day
+    (
+        '1985-04-12T23:20:30Z',
+        DateAndTime(Date('1985', '04', '12'), '23:20:30Z')
+    ),
+    # Date and time with timeshift in hours (only)
+    (
+        '1985-04-12T23:20:30-04',
+        DateAndTime(Date('1985', '04', '12'), '23:20:30-04')
+    ),
+    # Date and time with timeshift in hours and minutes
+    (
+        '1985-04-12T23:20:30+04:30',
+        DateAndTime(Date('1985', '04', '12'), '23:20:30+04:30')
     ),
 ])
 def test_parse_edtf(edtfstr, expected):


### PR DESCRIPTION
Fixes #11

:heart: Thank you for your contribution!

### Description

See description of the bug in #11.

* The bug is coming from the underlying version 4.0.1 of the PyPI package `edtf` (repo [`ixc/python-edtf`](https://github.com/ixc/python-edtf)) which we are currently using.
* The version 5.0.0 of this package was released in July 2024 after many years of inactivity.
* Version 5.0.0 does not have this bug.

The pull request can be reviewed commit by commit.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
