### PR TITLE
fix: consider DD_MM_YYYY invalid & 📦 release: v1.2.1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,10 @@
 Changes
 =======
 
+Version v1.2.1 (released 2024-11-07)
+
+- fix: consider DD_MM_YYYY invalid
+
 Version 1.2.0 (released 2024-10-28)
 
 - setup: upgrade edtf to 5.0.0 and fix bug with dates and times with hour 23

--- a/babel_edtf/__init__.py
+++ b/babel_edtf/__init__.py
@@ -8,6 +8,7 @@
 """Localization of Extended Date Time Format (EDTF) level 0 strings."""
 
 import calendar
+import re
 from datetime import date as date_
 
 from babel import Locale
@@ -25,6 +26,7 @@ from .version import __version__
 BOUND_LOWER = 'lower'
 BOUND_UPPER = 'upper'
 
+_isoparse_date_pattern = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 
 DATE_SKELETON_FORMATS = {
     PRECISION_YEAR: {
@@ -194,13 +196,13 @@ def _validate_leap_year(edtf_date):
 
 
 def parse_edtf(date):
-    """parse_edtf after trying isoparse for simple date formats.
+    """parse_edtf after trying isoparse for the simple date format YYYY-MM-DD.
 
     parse_edtf/pyparsing don't work in a thread safe way and throw
     TypeError randomly on some runs. This function tries to get isoparse first
     and then falls back to parse_edtf
     """
-    if len(date) == 10:
+    if len(date) == 10 and _isoparse_date_pattern.match(date):
         try:
             isodate = isoparse(date)
             return Date(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -215,6 +215,12 @@ def test_parse_edtf(edtfstr, expected):
     ('2021-02-29'),
     ('2021-02-29/2020-11-15'),
     ('2020-09-01/2021-02-29'),
+    # Badly formatted inputs
+    ('123456789'),
+    ('1234567890'),
+    ('12345678901'),
+    ('31-12-2020'),
+    ('31_12_2020'),
 ])
 def test_parse_edtf_invalid(edtfstr):
     """Test invalid values to parse_edtf."""


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

Providing `19_05_2024` as an input is wrongly considered by `isoparse` as `February 22, 190`.
This pull request only calls `isoparse` if the input matches the format "YYYY-MM-DD" (instead of only checking if the input length is 10 characters long) to avoid such wrong parsing.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
