### PR TITLE
fix(workflows): add relevant extras for tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,3 +18,5 @@ on:
 jobs:
   Python:
     uses: inveniosoftware/workflows/.github/workflows/tests-python.yml@master
+    with:
+      extras: "tests,docs"


### PR DESCRIPTION
The test workflow run failed because `sphinx` wasn't installed but required for the test run.